### PR TITLE
Update _documentation/utils/ofThread.markdown

### DIFF
--- a/_documentation/utils/ofThread.markdown
+++ b/_documentation/utils/ofThread.markdown
@@ -35,7 +35,7 @@ class MyThread : public ofThread {
 		// done
 	}
 	
-	ofVideoGrabber;	// the cam
+	ofVideoGrabber cam;	// the cam
 	ofImage image;
 };
 
@@ -102,8 +102,8 @@ class MyThread : public ofThread {
 		// done
 	}
 
-	ofVideoGrabber;	// the cam
-	ofImage image;  // the shared resource
+	ofVideoGrabber cam;	// the cam
+	ofImage image;		// the shared resource
 };
 
 ~~~~


### PR DESCRIPTION
Minor errors with missing variable name of the ofVideoGrabber == cam
