### PR TITLE
Add link to #openframeworks on freenode (in-browser)

### DIFF
--- a/_templates/header.mako
+++ b/_templates/header.mako
@@ -23,6 +23,7 @@
 			<li><span class="external-dot"> ></span>&nbsp;<a href="http://wiki.openframeworks.cc/" target="_blank">wiki</a></li>
 			<li><span class="external-dot"> ></span>&nbsp;<a href="http://github.com/openframeworks/openFrameworks" target="_blank">github</a></li>
 			<li><span class="external-dot"> ></span>&nbsp;<a href="http://openframeworks.cc/list-info" target="_blank">mailing list</a></li>
+			<li><span class="external-dot"> ></span>&nbsp;<a href="http://webchat.freenode.net?channels=openframeworks&uio=MT1mYWxzZSY5PXRydWUmMTE9Mjk39" target="_blank">IRC</a></li>
 		</ul>
 		
 			<!--form method="get" id="searchform" action="/index.php">


### PR DESCRIPTION
This is more of a proposition than a "please pull this"

This adds a link in the external links portion of the header to an in-browser IRC client that logs into #openframeworks on freenode.

Lately I've been keeping an #openframeworks session open on my IRC client every day, and maybe every ~3 days someone drifts in with a question. Seeing as how I don't think the channel is "official" in any way, it seems that it's intuitive enough that people just attempt to see if it exists on their own.

It'd be nice to make it a bit more public, as I think there's a lot to be gained from a sort of instant-gratification Q & A session. Especially for new users who really just to ask a lightweight question  / get a sanity check / "am I doing it right?" sort of thing, where a post on the forum is a bit too involved.

At any given time, it seems like there's roughly 8 people on #openframeworks, so it's not exactly a ghost town channel.

Whaddyathink?
