### PR TITLE
Update _documentation/graphics/ofImage_.markdown

### DIFF
--- a/_documentation/graphics/ofImage_.markdown
+++ b/_documentation/graphics/ofImage_.markdown
@@ -4,7 +4,7 @@
 ##Description
 
 
-The ofImage and is a useful object for loading, saving and drawing images in openFrameworks. ofImage is a convenient class that let's you both get draw images to the screen and manipulate their pixel data. The ofImage allows you to load image from disk, manipulate the pixels, and create an OpenGL texture that you can display and manipulate on the graphics card. Loading a file into the ofImage allocates an ofPixels and creates the ofTexture to display the pixels.
+The ofImage is a useful object for loading, saving and drawing images in openFrameworks. ofImage is a convenient class that let's you both draw images to the screen and manipulate their pixel data. The ofImage allows you to load an image from disk, manipulate the pixels, and create an OpenGL texture that you can display and manipulate on the graphics card. Loading a file into the ofImage allocates an ofPixels object and creates the ofTexture to display the pixels.
 
 ofImage uses a library called "freeImage" under the hood.
 


### PR DESCRIPTION
basic grammatical edits for clarity.

using the docs today, I noticed a few very minor grammatical errors in the description for ofImage. made changes that seemed to explain what the author intended.
