### PR TITLE
Fix typo in ofImage_.markdown (OF_IMAGE_COLOR_ALPHA)

### DIFF
--- a/_documentation/graphics/ofImage_.markdown
+++ b/_documentation/graphics/ofImage_.markdown
@@ -1883,7 +1883,7 @@ _description: _
 Set the pixels of the image from an array of values, for an ofFloatImage these need to be floats, for an ofImage these need to be unsigned chars. The w and h values are important so that the correct dimensions are set in the image. This assumes that you're setting the pixels from 0,0 or the upper left hand corner of the image.
 The bOrderIsRGB flag allows you pass in pixel data that is BGR by setting bOrderIsRGB=false.
 
-Copies in the pixel data from  the 'pixels' array. Specify the corresponding width and height of the image you are passing in with 'w' and 'h'. The image type can be OF_IMAGE_GRAYSCALE, OF_IMAGE_COLOR, or OF_IMAGE_COLORALPHA. 
+Copies in the pixel data from  the 'pixels' array. Specify the corresponding width and height of the image you are passing in with 'w' and 'h'. The image type can be OF_IMAGE_GRAYSCALE, OF_IMAGE_COLOR, or OF_IMAGE_COLOR_ALPHA. 
 
 Note: that your array has to be at least as big as [ width * height * bytes per pixel ]. 
 


### PR DESCRIPTION
Change OF_IMAGE_COLORALPHA for OF_IMAGE_COLOR_ALPHA in ofImage::setFromPixels(...)
