### PR TITLE
Fix doc error in ofFbo::setAnchorPercent(xPct, yPct) description

### DIFF
--- a/_documentation/gl/ofFbo.markdown
+++ b/_documentation/gl/ofFbo.markdown
@@ -1227,7 +1227,7 @@ _advanced: False_
 _description: _
 
 
-You can set the anchor position that the texture will be drawn at. This means that passing 50, 50 will draw the ofFbo center at the point you pass in to the draw() method.
+You can set the anchor position that the texture will be drawn at. This means that passing 0.5, 0.5 will draw the ofFbo center at the point you pass in to the draw() method.
 
 
 


### PR DESCRIPTION
Percentages have to be given in [0,1], not [0,100].
