### PR TITLE
Internal links are linking to the wrong subdirectory.

### DIFF
--- a/_controllers/documentation.py
+++ b/_controllers/documentation.py
@@ -79,8 +79,13 @@ def run():
     classes = []
     directory = "_documentation"
     documentation = bf.config.controllers.documentation
+    
+    module_lookup = dict()
         
     classes = markdown_file.getclass_list()
+      
+    for class_name in classes:
+        module_lookup[class_name] = markdown_file.getclass(class_name,True).module
     for clazz_name in classes:
         clazz = markdown_file.getclass(clazz_name,True)
 
@@ -93,12 +98,11 @@ def run():
 
         clazz.reference = str(clazz.reference)
         for class_name in classes:
-                ref_clazz = markdown_file.getclass(class_name,True)
                 rep = class_name + "[\s]"
-                clazz.reference = re.sub(rep, "<a href=\"../"+ref_clazz.module+"/"+class_name+".html\">"+class_name+"</a> ", clazz.reference)
+                clazz.reference = re.sub(rep, "<a href=\"../"+module_lookup[class_name]+"/"+class_name+".html\">"+class_name+"</a> ", clazz.reference)
                 rep = class_name + "[(]"
-                clazz.reference = re.sub(rep, "<a href=\"../"+ref_clazz.module+"/"+class_name+".html\">"+class_name+"</a>(", clazz.reference)
-                #print "Going through " + clazz.module + ":" + clazz.name +", replacing " + ref_clazz.module + ":" + class_name
+                clazz.reference = re.sub(rep, "<a href=\"../"+module_lookup[class_name]+"/"+class_name+".html\">"+class_name+"</a>(", clazz.reference)
+                #print "Going through " + clazz.module + ":" + clazz.name +", replacing " + module_lookup[class_name] + ":" + class_name
 
         functions_file = markdown_file.getfunctionsfile(clazz_name)
         #print clazz.name


### PR DESCRIPTION
Internal links between classes in different modules is referencing the module of the current class, not the module of the referenced class.

For example, on [ofImage](http://www.openframeworks.cc/documentation/graphics/ofImage.html), the link to ofTexture goes to http://www.openframeworks.cc/documentation/graphics/ofTexture.html, not http://www.openframeworks.cc/documentation/gl/ofTexture.html.

This pull request fixes the problem—I'm not very familiar with Python, so if there's a more efficient or idiomatic way to do this, please let me know.
