### PR TITLE
Added formatting for methods without documentation

### DIFF
--- a/_templates/documentation_class.mako
+++ b/_templates/documentation_class.mako
@@ -36,7 +36,13 @@
                  <% prevmethod = "" %>
                  % for method in clazz.function_list:
                      % if prevmethod != method.name and method.visible and not method.advanced and method.access=='public' and (method.name!=method.clazz) and (method.name != "~" + method.clazz):
-                         <li> <a href="#show_${method.name}" class="${method.name}">${method.name}()</a> </li>
+                         % if len(method.description) > 1:
+                            <li> 
+                         % else:
+                            <li class="nodocs">
+                         % endif
+                              <a href="#show_${method.name}" class="${method.name}">${method.name}()</a> 
+                            </li>
                      % endif
                      <% prevmethod = method.name %>
                  % endfor
@@ -51,7 +57,13 @@
                 <ul class="functionslist">
                      % for var in clazz.var_list:
                          % if var.visible and not var.advanced and var.access=='public':
-                             <li> <a href="#show_${var.name}" class="${var.name}">${var.type} ${var.name}</a> </li>
+                             % if len(var.description) > 1:
+                                 <li> 
+                              % else:
+                                 <li class="nodocs">
+                              % endif
+                                    <a href="#show_${var.name}" class="${var.name}">${var.type} ${var.name}</a>
+                                 </li>
                          % endif
                      % endfor
                  </ul>
@@ -66,7 +78,13 @@
                      <% prevmethod = "" %>
                      % for method in functions.function_list:
                          % if prevmethod != method.name and method.visible and not method.advanced:
-                             <li> <a href="#show_${method.name}" class="${method.name}">${method.name}()</a> </li>
+                             % if len(method.description) > 1:
+                                 <li> 
+                              % else:
+                                 <li class="nodocs">
+                              % endif
+                                    <a href="#show_${method.name}" class="${method.name}">${method.name}()</a>
+                                 </li>
                          % endif
                          <% prevmethod = method.name %>
                      % endfor

--- a/css/style.css
+++ b/css/style.css
@@ -541,6 +541,9 @@ a.nohover {
 	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
 	cursor: pointer; cursor:hand;
 }
+.functionslist .nodocs a{
+  color: #888;
+}
 .functionslist a:hover, .documentation_index_group a:hover {
 	color: white;
 }


### PR DESCRIPTION
This is a first pass on issue #182— it grays out methods, variables, and functions on the left sidebar of the class page that do not have any documentation.

I didn't implement it on the main page—if people are interested, that's not a hard addition.   Also, I'm not sure what the inline doc code that was added today by arturo does—this pull request doesn't touch that code that at all.

Thoughts?
