### PR TITLE
Updates for documentation viewer.

### DIFF
--- a/_templates/documentation_class.mako
+++ b/_templates/documentation_class.mako
@@ -41,7 +41,7 @@
                          % else:
                          <li>
                          % endif
-                         <a href="#show_${method.name}" class="${method.name}">${method.name}()</a></li>
+                         <a href="#show_${method.name}" class="${method.name}" data-lookup="${method.name}">${method.name}()</a></li>
                      % endif
                      <% prevmethod = method.name %>
                  % endfor
@@ -61,7 +61,7 @@
                             % else:
                             <li>
                             % endif
-                            <a href="#show_${var.name}" class="${var.name}">${var.type} ${var.name}</a> </li>
+                            <a href="#show_${var.name}" class="${var.name}" data-lookup="${var.name}">${var.type} ${var.name}</a> </li>
                          % endif
                      % endfor
                  </ul>
@@ -81,7 +81,7 @@
                             % else:
                             <li>
                             % endif
-                            <a href="#show_${method.name}" class="${method.name}">${method.name}()</a></li>
+                            <a href="#show_${method.name}" class="${method.name}" data-lookup="${method.name}">${method.name}()</a></li>
                          % endif
                          <% prevmethod = method.name %>
                      % endfor

--- a/_templates/documentation_function.mako
+++ b/_templates/documentation_function.mako
@@ -1,7 +1,7 @@
 <%page args="function"/>
-<div class="documentation_detail ${function.name}">
+<div class="documentation_detail ${function.name}" data-lookup="${function.name}" data-item-type="function">
   	<% params = "()" if function.parameters=="" else "(...)" %> 
-	<h1><a name="${function.name}">${function.name}${params}</a></h1>
+	<h1><a name="show_${function.name}">${function.name}${params}</a></h1>
 	<h2><%self:filter chain="markdown_template">${function.returns} ${function.name}(${function.parameters})</%self:filter></h2>
 	<div class="documentation_detail_description">
 		${function.summary}

--- a/_templates/documentation_method.mako
+++ b/_templates/documentation_method.mako
@@ -1,7 +1,7 @@
 <%page args="method"/>
-<div class="documentation_detail ${method.name}">
+<div class="documentation_detail ${method.name}" data-lookup="${method.name}" data-item-type="method">
   	<% params = "()" if method.parameters=="" else "(...)" %> 
-	<h1><a name="${method.name}">${method.name}${params}</a></h1>
+	<h1><a name="show_${method.name}">${method.name}${params}</a></h1>
 	<h2><%self:filter chain="markdown_template">${method.returns} ${method.clazz}::${method.name}(${method.parameters})</%self:filter></h2>
 	<div class="documentation_detail_description">
 		${method.summary}

--- a/_templates/documentation_var.mako
+++ b/_templates/documentation_var.mako
@@ -1,6 +1,6 @@
 <%page args="var"/>
-<div class="documentation_detail  ${var.name}">
-	<h1>${var.type} <a name="${var.name}">${var.name}</a></h1>
+<div class="documentation_detail  ${var.name}" data-lookup="${var.name}" data-item-type="var">
+	<h1>${var.type} <a name="show_${var.name}">${var.name}</a></h1>
 	<h2><%self:filter chain="markdown_template">${var.type} ${var.clazz}::${var.name}</%self:filter></h2>
 	<div class="documentation_detail_description">
 		<%self:filter chain="syntax_highlight,markdown_template">

--- a/css/style.css
+++ b/css/style.css
@@ -22,16 +22,12 @@ body {
     padding-right: 0.3em;
     color: #009bca;
 }
-#body-wrap ul li:before {
-    content: '> ';
-    padding-right: 0.3em;
-    color: #009bca;
-}
 #body-wrap ul li.docs-module-title:before{
     content: '';
     padding-right: 0.3em;
     color: #009bca;
 }
+
 #content {
 	box-shadow: 5px 5px 5px #aaa, -5px 0 5px #aaa;
 	margin: auto;
@@ -743,6 +739,17 @@ a.docs_class{
 	padding: 0px 0px 10px 0px;
 	position: relative;
 }
+
+/* BEGIN Fixes for documentation containing unordered lists */
+#body-wrap .documentation_detail_description li:before {
+  content: none;
+}
+#body-wrap .documentation_detail_description li {
+  list-style-type: disc;
+}
+/* END Fixes for documentation containing unordered lists */
+
+
 .hide_core_functions, .hide_addons_functions, .collapse_core, .collapse_addons{
     cursor:pointer;cursor:hand;
 }
@@ -1274,7 +1281,7 @@ div.log {padding-left:2em;}
 #body-wrap ul li.noDoc:before{
     content: '> ';
     padding-right: 0.3em;
-    color: #999;
+    color: #bbb;
 }
 
 


### PR DESCRIPTION
While working on the documentation for the ofRectangle class I ran into a bunch of issues with the Javascript navigation.   For instance, trying to navigate to any method with non-alphanumeric characters in it doesn't work, or that the back button breaks while navigating through the documentation.

I've gone through and fixed as much as I could.  I don't know what has been discussed before, and don't want to rehash things that I don't know about—is it better to break this into a bunch of smaller pull requests?

Additionally, I haven't been able to test the javascript changes in IE, since I don't have a Windows machine.  It does work in current Mac versions of Safari, Opera, Firefox, and Chrome, and I did put in fallbacks where I could.

**Style changes:**
- Removed a duplicated definition.
- Updated the style for unordered lists within documentation.
- lightened the carat for missing documentation.

**Template changes:**
- Updated the named anchors so the links and the anchors match. (The anchors were missing the `show_`).
- added a data-lookup parameter to class methods, functions, and variables.  This is to deal with the fact that many of the common characters in method names (like == or +) are not allowed in class names, which meant that trying to go to those methods didn't work.
- added a data-item-type parameter to class methods, functions, and variables.  This allows the page title formatting for each to vary based on item type.

**Javascript changes:**
- Got rid of the unused columnize call.
- Changed the documentation search from using class name to using data-lookup parameters.
- Made the page title change dynamically based on the current method, not just the current class.
- Fixed the behavior of the back button—it now will correctly go through the on-page navigation, as opposed to doing nothing, but going back through all the anchors.
- extracted duplicate code into functions, added some documentation.
