### PR TITLE
Fixed markdown image syntax example.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ To insert code snippets use four tildes followed by curly braces with ".cpp" ins
 
 Images are added using normal markdown format:
 
-![Image Title](filename.png "alt text")
+    ![Image Title](filename.png "alt text")
 
 Additional tips can be found in [Contributing Documentation](https://github.com/openframeworks/ofSite/wiki/Contributing-documentation) on the [ofSite wiki](https://github.com/openframeworks/ofSite/wiki)
 


### PR DESCRIPTION
The example for image syntax wasn't indented—so it was acting as an actual (broken) image, not an example.   Indenting it properly fixes that.
