### PR TITLE
Handle newlines in *_functions.markdown files correctly.

### DIFF
--- a/_tools/markdown_file.py
+++ b/_tools/markdown_file.py
@@ -75,6 +75,7 @@ def getfunctionsfile(filename):
     functionsfile.name = filename
     functionsfile.new = 1                        
     function = DocsFunction(0)
+    prevBreakLine = False;
     for root, dirs, files in os.walk(os.path.join(documentation_root)):
         for name in files:
             file_split = os.path.splitext(name)
@@ -90,8 +91,10 @@ def getfunctionsfile(filename):
                         functionsfile.new = False
                     elif state == 'functionsfile' and line.find('##Description') == 0:
                         state = 'filedescription'
-                    elif state == 'filedescription' and line.find('<!----------------------------------------------------------------------------->')==-1 and line!='\n':
+                        prevBreakLine = False
+                    elif state == 'filedescription' and line.find('<!----------------------------------------------------------------------------->')==-1 and (line!='\n' or not prevBreakLine):
                         functionsfile.description = functionsfile.description + line
+                        prevBreakLine = (line=='\n')                        
                     elif state == 'filedescription' or state=='description' and line.find('###')==0:
                         if(state=='description'):
                             functionsfile.function_list.append(function)
@@ -102,8 +105,10 @@ def getfunctionsfile(filename):
                         addfield(function,line)
                     elif state == 'function' and line.find('_description')==0:
                         state = 'description'
-                    elif state == 'description' and line.find('<!----------------------------------------------------------------------------->')==-1 and line!='\n':
+                        prevBreakLine = False
+                    elif state == 'description' and line.find('<!----------------------------------------------------------------------------->')==-1 and (line!='\n' or not prevBreakLine):
                         function.description = function.description + line
+                        prevBreakLine = (line=='\n')                        
                                     
                 if(state=='description'):
                     functionsfile.function_list.append(function)


### PR DESCRIPTION
There is code in the `getclass` method that handles method and variable descriptions in the markdown files which  contain newlines, preventing the parser from stripping them out.

I've added the same code to the `getfunctionsfile` method, so  function documentation newlines are no longer stripped.

This addresses problems that I found in the `ofRectangle_functions.markdown` documentation, as well as (at least the newline parts of) issue #56.
