### PR TITLE
Added explicit style for markdown inline code formatting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -739,6 +739,14 @@ a.docs_class{
 	position: relative;
 }
 
+/* BEGIN unify formatting for markdown ``inline code blocks`` */
+.class_documentation code, .documentation_detail_description code{
+  font-size: 12px;
+  font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;	
+}
+/* END unify formatting for markdown ``inline code blocks`` */
+
+
 /* BEGIN Fixes for documentation containing unordered lists */
 #body-wrap .documentation_detail_description li:before {
   content: none;


### PR DESCRIPTION
Code blocks referenced in Markdown using `` blocks are not explicitly formatted, so they appear as 10pt text in the class descriptions and 12pt test in the function description.   This explicitly declares a size and uses the same font-family stack as the rest of the code.

This fixes issue #55.  
