### PR TITLE
fixed broken parentheses in the demo cpp code for the getPixels method

### DIFF
--- a/_documentation/video/ofVideoPlayer.markdown
+++ b/_documentation/video/ofVideoPlayer.markdown
@@ -592,10 +592,11 @@ For example, to get the red, green, and blue of the pixel at (100,20):
 
 ~~~~{.cpp}
 unsigned char * pixels = myMovie.getPixels();
+int nChannels = movie.getPixelsRef().getNumChannels();
 int widthOfLine = myMovie.width;  // how long is a line of pixels
-int red 	= pixels[(20 * widthOfLine) + 100 * 3    ];
-int green 	= pixels[(20 * widthOfLine) + 100 * 3 + 1];
-int blue 	= pixels[(20 * widthOfLine) + 100 * 3 + 2];
+int red 	= pixels[(20 * widthOfLine + 100) * nChannels    ];
+int green 	= pixels[(20 * widthOfLine + 100) * nChannels + 1];
+int blue 	= pixels[(20 * widthOfLine + 100) * nChannels + 2];
 ~~~~
 
 


### PR DESCRIPTION
Hi, I noticed in the "getPixels" method for the VideoPlayer doc, the parentheses group the parameters such that the calculated index is always too small. Try getting the index for pixel at (h,w) for some image that is dimensions h by w and you will see what I mean.
