### PR TITLE
Fix minor #include typo in shader tutorial

### DIFF
--- a/_tutorials/03_graphics/shaders.markdown
+++ b/_tutorials/03_graphics/shaders.markdown
@@ -75,7 +75,7 @@ Before we go get into trouble, there's something that I want to explain that mig
 #include "ofMain.h"
 #include "ofApp.h"
 // import the fancy new renderer
-#include "ofGlProgrammableRenderer.h"
+#include "ofGLProgrammableRenderer.h"
 
 int main( ){
 


### PR DESCRIPTION
It actually compiles fine as-is (on OSX, anyway), but the actual file being included is ofG_L_ProgrammableRenderer.h
