### PR TITLE
remove Japanese Link

### DIFF
--- a/_templates/header.mako
+++ b/_templates/header.mako
@@ -46,9 +46,6 @@
                 <span class='but'><input type="submit" name="unsub" value="unsubscribe" /></span>
             </form-->
         <ul class="submenu">
-            <li>english</li>
-            <li>/</li>
-            <li><a href="http://openframeworks.jp">japanese</a></li>
         </ul>
 		</div>
 </div><!-- head -->


### PR DESCRIPTION
openFrameworks Japanese page is not updated long days and Can’t send
Update Request. many JP openFrameworks beginner will be confused.
