### PR TITLE
mentioning ofExit() in ofBaseApp::exit()

### DIFF
--- a/_documentation/application/ofBaseApp.markdown
+++ b/_documentation/application/ofBaseApp.markdown
@@ -16,7 +16,7 @@ _istemplated: False_
 
 ##Description
 
-The openframeworks engine is contained in the "app" category. The project works, similar to processing, in that you have a base class which extends a class that already exists. In the case of OF, there is a class called "ofBaseApp" which contains various event driven functions. When you create an OF project, you use a main.cpp which is the boot-strap, that kicks off the application and another class, which inherits the properties of ofBaseApp. Essentially, when you write code in the testApp, you are re-writing already defined functions that exist in OF, such as update, draw, etc.
+The openFrameworks engine is contained in the "app" category. The project works, similar to processing, in that you have a base class which extends a class that already exists. In the case of OF, there is a class called "ofBaseApp" which contains various event driven functions. When you create an OF project, you use a main.cpp which is the boot-strap, that kicks off the application and another class, which inherits the properties of ofBaseApp. Essentially, when you write code in the testApp, you are re-writing already defined functions that exist in OF, such as update, draw, etc.
 
 In versions pre 0.06 this class was called ofSimpleApp
 
@@ -870,7 +870,7 @@ _inlined_description: _
 _description: _
 
 
-The openframeworks engine is contained in the "app" category. The project works, similar to processing, in that you have a base class which extends a class that already exists. In the case of OF, there is a class called "ofBaseApp" which contains various event driven functions. When you create an OF project, you use a main.cpp which is the boot-strap, that kicks off the application and another class, which inherits the properties of ofSimpleApp. Essentially, when you write code in the ofApp, you are re-writing already defined functions that exist in OF, such as update, draw, etc.
+The openFrameworks engine is contained in the "app" category. The project works, similar to processing, in that you have a base class which extends a class that already exists. In the case of OF, there is a class called "ofBaseApp" which contains various event driven functions. When you create an OF project, you use a main.cpp which is the boot-strap, that kicks off the application and another class, which inherits the properties of ofSimpleApp. Essentially, when you write code in the ofApp, you are re-writing already defined functions that exist in OF, such as update, draw, etc.
 
 
 

--- a/_documentation/application/ofBaseApp.markdown
+++ b/_documentation/application/ofBaseApp.markdown
@@ -221,7 +221,7 @@ _inlined_description: _
 _description: _
 
 
-Add this function to your ofApp to have it called at the moment before the app is terminated. This is useful for doing cleanup stuff or making sure files are saved before the app terminates.
+Add this function to your ofApp to have it called at the moment before the app is terminated. This is useful for doing cleanup stuff or making sure files are saved before the app terminates. If you want to terminate the execution of your ofApp (from the inside), call ofExit().
 
 
 


### PR DESCRIPTION
Hi,

this change points out the use of `ofExit()` in the documentation of `ofApp::exit()`. This follows the suggestion (and hopefully closes) [issue 3411](https://github.com/openframeworks/openFrameworks/issues/3411) in the openFrameworks repo.
Cheers,
tpltnt