### PR TITLE
getPixelsRef() -> getPixels() in example code

### DIFF
--- a/_documentation/addons/ofxOpenCv/ofxCvColorImage.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvColorImage.markdown
@@ -302,7 +302,7 @@ Maps the pixels of an image to the min and max range passed in.
 
 ~~~~{.cpp}
 
-colors.setFromPixels(grabber.getPixelsRef());
+colors.setFromPixels(grabber.getPixels());
 
 first = colors; // will leave unaltered
 second = colors; // change it

--- a/_documentation/addons/ofxOpenCv/ofxCvContourFinder.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvContourFinder.markdown
@@ -69,7 +69,7 @@ void ofApp::update(){
     vidGrabber.update();
     //do we have a new frame?
     if (vidGrabber.isFrameNew()){
-        colorImg.setFromPixels(vidGrabber.getPixelsRef());
+        colorImg.setFromPixels(vidGrabber.getPixels());
         grayImage = colorImg; // convert our color image to a grayscale image
         if (bLearnBackground == true) {
             grayBg = grayImage; // update the background image

--- a/_documentation/addons/ofxOpenCv/ofxCvGrayscaleImage.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvGrayscaleImage.markdown
@@ -25,7 +25,7 @@ grayscaleImg = colorImg;
 A common routine that you'll see is something like the following:
 
 ~~~~{.cpp}
-colorImg.setFromPixels(vidGrabber.getPixelsRef());
+colorImg.setFromPixels(vidGrabber.getPixels());
 grayImage = colorImg; // convert our color image to a grayscale image
 ~~~~
 
@@ -334,7 +334,7 @@ Maps the pixels of an image to the min and max range passed in.
 
 ~~~~{.cpp}
 
-colors.setFromPixels(grabber.getPixelsRef());
+colors.setFromPixels(grabber.getPixels());
 
 first = colors; // will leave unaltered
 second = colors; // change it

--- a/_documentation/addons/ofxOpenCv/ofxCvHaarFinder.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvHaarFinder.markdown
@@ -125,7 +125,7 @@ Takes an input ofImage object and allows you to set the minimum width and height
 camera.grabFrame();
 if(camera.isFrameNew())
 {
-	img.setFromPixels(grab.getPixelsRef());
+	img.setFromPixels(grab.getPixels());
 	finder.findHaarObjects(img);
 }
 ~~~~
@@ -211,7 +211,7 @@ _description: _
 Takes an input ofxCvGrayscaleImage object and allows you to set the minimum width and height of areas that should be returned and a region of interest as an ofRectangle that you would like to limit haar finding to.
 
 ~~~~{.cpp}
-colorImg.setFromPixels(vidGrabber.getPixelsRef());
+colorImg.setFromPixels(vidGrabber.getPixels());
 grayImage = colorImg; // convert our color image to a grayscale image
 
 faceFinder.findHaarObjects(grayImage);

--- a/_documentation/addons/ofxOpenCv/ofxCvImage.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvImage.markdown
@@ -262,7 +262,7 @@ Maps the pixels of an image to the min and max range passed in.
 
 ~~~~{.cpp}
 
-colors.setFromPixels(grabber.getPixelsRef());
+colors.setFromPixels(grabber.getPixels());
 
 first = colors; // will leave unaltered
 second = colors; // change it

--- a/_documentation/addons/ofxOpenCv/ofxCvShortImage.markdown
+++ b/_documentation/addons/ofxOpenCv/ofxCvShortImage.markdown
@@ -256,7 +256,7 @@ Maps the pixels of an image to the min and max range passed in.
 
 ~~~~{.cpp}
 
-colors.setFromPixels(grabber.getPixelsRef());
+colors.setFromPixels(grabber.getPixels());
 
 first = colors; // will leave unaltered
 second = colors; // change it

--- a/_documentation/graphics/ofImage_.markdown
+++ b/_documentation/graphics/ofImage_.markdown
@@ -71,8 +71,8 @@ This allocates space in the ofImage, both the ofPixels and the ofTexture that th
 ~~~~{.cpp}
 img.allocate(640, 480, OF_IMAGE_COLOR);
 int i = 0;
-while ( i < img.getPixelsRef().size() ) {
-    img.getPixelsRef()[i] = abs(sin( float(i) / 18.f)) * 255.f; // make some op-art
+while ( i < img.getPixels().size() ) {
+    img.getPixels()[i] = abs(sin( float(i) / 18.f)) * 255.f; // make some op-art
     i++;
 }
 img.reloadTexture();
@@ -173,8 +173,8 @@ This binds the ofTexture instance that the ofImage contains so that it can be us
 void ofApp::setup() {
     img.allocate(256, 256, OF_IMAGE_COLOR);
     int i = 0;
-    while ( i < img.getPixelsRef().size() ) {
-        img.getPixelsRef()[i] = abs(sin( float(i) / 18.f )) * 255.f;
+    while ( i < img.getPixels().size() ) {
+        img.getPixels()[i] = abs(sin( float(i) / 18.f )) * 255.f;
         i++;
     }
     img.reloadTexture();

--- a/_documentation/utils/ofThread.markdown
+++ b/_documentation/utils/ofThread.markdown
@@ -59,7 +59,7 @@ class MyThread : public ofThread {
 			if(cam.isFrameNew()) {
 		
 				// load the image
-				image.setFromPixels(cam.getPixelsRef());
+				image.setFromPixels(cam.getPixels());
 			}
 		}
 	
@@ -128,7 +128,7 @@ class MyThread : public ofThread {
 				lock();
 				
 				// load the image
-				image.setFromPixels(cam.getPixelsRef());	
+				image.setFromPixels(cam.getPixels());	
 				// done with the resource
 				unlock();
 			}	


### PR DESCRIPTION
 This change replaces `getPixelsRef()` with `getPixels()` in most example code since `getPixelsRef()` is deprecated (according to compiler warnings). Only ofVideoPlayer example code was left untouched.
Cheers,
tpltnt