### PR TITLE
android studio tips

### DIFF
--- a/setup/android-studio/index.html.mako
+++ b/setup/android-studio/index.html.mako
@@ -104,6 +104,8 @@ Troubleshooting
     - The `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion`, `targetSdkVersion` values
         in `/addons/ofxAndroid/ofAndroidLib/build.gradle` and `/apps/myApps/androidEmptyExample/build.gradle`
 
+- If you get make errors on gradle sync without any details, run `chmod +x gradlew; ./gradlew` from within the project folder to build the project from command line, and get more detailed error messages.
+
 - If you get strange linker errors, check that you are using the 10e version of the NDK. Newer NDKs might work but usually there's some always some fixes that need to be done when moving to a new NDK version.
 
 - If your connected device is not recognized by Android Studio, restart adb


### PR DESCRIPTION
```
If you get make errors on gradle sync without any details, run `chmod +x gradlew; ./gradlew` from within the project folder to build the project from command line, and get more detailed error messages.
```