### PR TITLE
description for ofCreateWindow

### DIFF
--- a/_documentation/application/ofAppRunner_functions.markdown
+++ b/_documentation/application/ofAppRunner_functions.markdown
@@ -77,7 +77,9 @@ _inlined_description: _
 
 _description: _
 
+Creates a new app window and returns it as a shared_ptr. You can change the window's settings, like its size, position, decoration, and resizability in its ofWindowSettings.
 
+To share assets between multiple windows, such as for drawing any ofBaseHasPixels object, you have to share contexts. This can be done by pointing a window to the shareContextWith field in another window's settings, as in the multiWindowOneAppExample.
 
 
 


### PR DESCRIPTION
added description for ofCreateWindow and note about sharing contexts for passing assets (like pixels) between windows. not sure if this is worded perfectly, worth looking over.