### PR TITLE
Typo fix on worldToScreen

### DIFF
--- a/_documentation/3d/ofCamera.markdown
+++ b/_documentation/3d/ofCamera.markdown
@@ -1359,7 +1359,7 @@ Returns: An ofVec3f containing the screen coordinates of your 3D point of intere
 
 _description: _
 
-When you have a position in world coordinates you can get what it would be in world coordinates, transforming it using the ofCamera.
+When you have a position in world coordinates you can get what it would be in screen coordinates, transforming it using the ofCamera.
 
 
 


### PR DESCRIPTION
Used to say: When you have a position in world coordinates you can get what it would be in world coordinates, transforming it using the ofCamera.

Changed to say: When you have a position in world coordinates you can get what it would be in screen coordinates, transforming it using the ofCamera.