### PR TITLE
Make main page links absolute

### DIFF
--- a/index.html.mako
+++ b/index.html.mako
@@ -15,10 +15,10 @@
     <div class="home-links">
         <h2>openFrameworks is an open source C++ toolkit for creative coding.</h2>
 
-        <h3><a href="/download/">download</a></h3>
+        <h3><a href="${bf.config.site.url}/download/">download</a></h3>
         <p>Grab the most recent release (${bf.config.currentVersion}) and follow the setup guide to get openFrameworks running.</p>
         
-	<h3><a href="/documentation/">documentation</a></h3>
+	<h3><a href="${bf.config.site.url}/documentation/">documentation</a></h3>
 	<p>Reference for openFrameworks classes, functions and addons. You can also check the <a href="http://openframeworks.cc/tutorials">tutorials section<a>.</p>
         
 	<h3><a href="http://forum.openframeworks.cc/">forum</a></h3>

--- a/index.html.mako
+++ b/index.html.mako
@@ -15,10 +15,10 @@
     <div class="home-links">
         <h2>openFrameworks is an open source C++ toolkit for creative coding.</h2>
 
-        <h3><a href="download/">download</a></h3>
+        <h3><a href="/download/">download</a></h3>
         <p>Grab the most recent release (${bf.config.currentVersion}) and follow the setup guide to get openFrameworks running.</p>
         
-	<h3><a href="documentation/">documentation</a></h3>
+	<h3><a href="/documentation/">documentation</a></h3>
 	<p>Reference for openFrameworks classes, functions and addons. You can also check the <a href="http://openframeworks.cc/tutorials">tutorials section<a>.</p>
         
 	<h3><a href="http://forum.openframeworks.cc/">forum</a></h3>


### PR DESCRIPTION
Some links on the main page linked to relative pages (download/ instead of /download/), causing problems when entering the site through an invallid URL because instead of a 404 page, the main page is shown at the invalid URL leading to broken links. For example, try following this link: [openframeworks.cc/0.9.0/](http://openframeworks.cc/0.9.0/) (as mentioned in [this forumpost](http://forum.openframeworks.cc/t/0-9-0-documentation/21268)) and click the download button in the right column. Instead of being redirected to the download page, you keep seeing the same frontpage, only with **download** added to the URL.