### PR TITLE
rpi2: recommend armv6 when using raspbian and point out some armv7 alternatives

### DIFF
--- a/setup/raspberrypi/Raspberry-Pi-8-9-Transition-Notes.html.mako
+++ b/setup/raspberrypi/Raspberry-Pi-8-9-Transition-Notes.html.mako
@@ -10,7 +10,7 @@ Raspberry Pi Transition Notes
 openFrameworks 0.9.0 uses C++11 features that require GCC 4.9 in order to compile. Raspbian Wheezy only supports GCC 4.8.
 
 ## Arm7 now default variant
-openFrameworks uses a variant system that allows developers to more easily port to new platforms. The Raspberry Pi 1 uses an armv6 architecture and the RPI2 uses armv7. Since the RPI2 is very popular, openFrameworks assumes that if you are on an arm7 architecture you are using an RPI2. 
+openFrameworks uses a variant system that allows developers to more easily port to new platforms. The Raspberry Pi 1 uses an armv6 architecture and although the RPI2 uses armv7 unless you are using archlinux or another distribution that is compiled for arm7 support we recommend to use the armv6 version of openFrameworks with raspbian since it's compiled for that architecture and mixing binaries for different architectures has shown some problems in the past.
 
 ## Cross-compiling
 With Wheezy and openFrameworks 0.84 you were able to use the cross-compiling tools provided by the [RPI Foundation](https://github.com/raspberrypi/tools). However these tools currently use GCC 4.8 which is not compatible with C++11. 

--- a/setup/raspberrypi/Raspberry-Pi-Getting-Started.html.mako
+++ b/setup/raspberrypi/Raspberry-Pi-Getting-Started.html.mako
@@ -45,17 +45,11 @@ Unlike Wheezy, Debian Jessie does not display the IP address on boot. You may wi
 ## Download openFrameworks
 You now can download openFrameworks and uncompress it into a folder. Using a Shell, The following commands will download openFrameworks and uncompress it into the folder `/home/pi/openFrameworks`
  
-<h3> For the Raspberry Pi 1/arm6</h3>
+<h3> For the Raspberry Pi 1 and 2 using OF for arm6</h3>
     * `cd` 
     * `curl -O http://www.openframeworks.cc/versions/v0.9.0/of_v0.9.0_linuxarmv6l_release.tar.gz` 
     * `mkdir openFrameworks`
     * `tar vxfz of_v0.9.0_linuxarmv6l_release.tar.gz -C openFrameworks --strip-components 1`
-
-<h3> For the Raspberry Pi 2/arm7</h3>
-    * `cd` 
-    * `curl -O http://www.openframeworks.cc/versions/v0.9.0/of_v0.9.0_linuxarmv7l_release.tar.gz` 
-    * `mkdir openFrameworks`
-    * `tar vxfz of_v0.9.0_linuxarmv7l_release.tar.gz -C openFrameworks --strip-components 1`
 
 ## Install packages and compile openFrameworks:
  Make sure you didn't skip the Memory Split step in the above section _**Configure the Raspberry Pi**_ or it will eventually fail.
@@ -67,15 +61,10 @@ Assuming openFrameworks is located at `/home/pi/openFrameworks` run the followin
     * `sudo ./install_dependencies.sh` 
 
 You are now ready to compile openFrameworks! 
-
-### For the Raspberry Pi 1/arm6
     * `make Release -C /home/pi/openFrameworks/libs/openFrameworksCompiled/project`
 
-### For the Raspberry Pi 2/arm7
-    * `make Release -j4 -C /home/pi/openFrameworks/libs/openFrameworksCompiled/project`
-
 ## Speeding up compiling
-Compiling natively on the Raspberry Pi 1 takes a long time. openFrameworks applications typically take much less time than the core library. Taking the time to set up a cross-compiling solution will save you enormous amounts of time. 
+Compiling natively on the Raspberry Pi takes a long time. openFrameworks applications typically take much less time than the core library. Taking the time to set up a cross-compiling solution will save you enormous amounts of time. 
 
 [Raspberry Pi Cross Compiling Guide](Raspberry-Pi-Cross-compiling-guide.html)
 

--- a/setup/raspberrypi/index.html.mako
+++ b/setup/raspberrypi/index.html.mako
@@ -15,6 +15,8 @@ Similiar to the desktop-based platforms, openFrameworks provides a common interf
 
 openFrameworks 0.9.0 supports the Raspberry Pi via the recommended Linux distribution Raspbian "Jessie" (hard float). Wheezy can be used with older versions of openFrameworks (0.84 recommended). [See here for the older versions of this guide that talk about Wheezy](Raspberry-Pi-Wheezy-index.html)
 
+On the Raspberry 2 although it's architecture is arm7 raspbian only supports arm6 by now so be sure to download that version as is explained in the [getting started guide](Raspberry-Pi-Getting-Started.html). If you want to use arm7 binaries with the raspberry PI 2 you can try other distributions like archlinux or ubuntu core and the arm7 download of OF but this is still not very well tested so some changes might be required to the original install scripts.
+
 If you are an existing openFrameworks/RPi user you may wish to read [what's different in 0.9.0](Raspberry-Pi-8-9-Transition-Notes.html) 
 
 ## Getting Started


### PR DESCRIPTION


merge with: https://github.com/openframeworks/openFrameworks/pull/4704