### PR TITLE
adding build info on osx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,17 @@ The `documentation` folder contains the OF API reference and are also in markdow
 
 This site is based on [nikola](https://getnikola.com). There's some scripts in the root folder to make it easier to install and use.
 
-- ./install.sh will install nikola and all the needed dependencies, by now is only tested on linux but should work in osx once python3, pip and asciidoc are installed in the system
+- ./install.sh will install nikola and all the needed dependencies. By now is only tested on linux and osx. On osx, before to run this script, you need first to install these packages:
+  ```bash
+  brew install
+  brew install python3
+  brew install asciidoc
+  brew linkapps python3
+  ```
+  and add this to your .basrc or zhsrc file
+  `export XML_CATALOG_FILES="/usr/local/etc/xml/catalog"`
 
-- ./auto_build.sh will run nikola and build the web every time any file is modified
+- ./auto_build.sh will run nikola and build the web every time any file is modified. If, on osx, you receive this error: `FileNotFoundError: [Errno 2] No such file or directory: 'asciidoctor'`, you need to install asciidoctor as explained [here](http://asciidoctor.org/docs/install-asciidoctor-macosx/), and then run the script again.
 
 - ./serve.sh will start a local web server that serves the site and opens it in the browser
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,6 @@ This site is based on [nikola](https://getnikola.com). There's some scripts in t
   ```bash
   brew install
   brew install python3
-  brew install asciidoc
   brew linkapps python3
   ```
   and add this to your .basrc or zhsrc file

--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,8 @@ This site is based on [nikola](https://getnikola.com). There's some scripts in t
 
 - ./install.sh will install nikola and all the needed dependencies. By now is only tested on linux and osx. On osx, before to run this script, you need first to install these packages:
   ```bash
-  brew install
   brew install python3
+  sudo easy_install pip
   brew linkapps python3
   ```
   and add this to your .basrc or zhsrc file


### PR DESCRIPTION
Hi, I've tested the build script on osx. It works, but it needs some workaround that are probably worth to be  explained. The major one is the installation of asciidoctor through rubygems. It would be nice to find a solution that avoid to install also ruby after python, in order to make the installation process smoother.

Without installing `asciidoctor` I was having this error running `auto_build.sh`:
```bash
TaskError - taskid:render_posts:cache/tutorials/01_introduction/001_chapter1.ja.html
PythonAction Error
Traceback (most recent call last):
  File "/Users/da1/Sources/OF/ofSiteFork/plugins/asciidoc/asciidoc.py", line 56, in compile_html
    subprocess.check_call((binary, '-b', 'html5', '-s', '-o', dest, source))
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/subprocess.py", line 579, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/subprocess.py", line 560, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/subprocess.py", line 950, in __init__
    restore_signals, start_new_session)
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/subprocess.py", line 1540, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'asciidoctor'

```

After installing `asciidoctor`, the script still returns an error:

```bash
2016-01-29 10:57 python3.5[42680] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 923, in _bootstrap_inner
    self.run()
  File "/Users/da1/Sources/OF/ofSiteFork/nikola/lib/python3.5/site-packages/fsevents.py", line 126, in run
    self._schedule(stream)
  File "/Users/da1/Sources/OF/ofSiteFork/nikola/lib/python3.5/site-packages/fsevents.py", line 150, in _schedule
    schedule(self, stream, callback, stream.paths, stream.since, stream.latency, stream.cflags)
SystemError: <built-in function schedule> returned NULL without setting an error
```

But at least i can open the website locally in the browser
