### PR TITLE
Explain default settings of ofCamera constructor.

### DIFF
--- a/documentation/3d/ofCamera.markdown
+++ b/documentation/3d/ofCamera.markdown
@@ -827,6 +827,7 @@ Construct a default camera.
 
 _description: _
 
+The default camera is positioned at (0, 0, 0) with a 60 degree field of view.  Its up vector is the positive y-axis, and it is looking down the negative z-axis.  Near and far planes are determined by the current viewport size.
 
 
 


### PR DESCRIPTION
Added explanation to _description section so it won't get overwritten by the _inlined_description which is auto-generated by comments in the code.