### PR TITLE
Correction for Screenshot Howto

### DIFF
--- a/learning/02_graphics/how_to_screenshot.markdown
+++ b/learning/02_graphics/how_to_screenshot.markdown
@@ -29,7 +29,7 @@ Next, trigger grabbing and saving the screen. Here, when "x" is pressed, a recta
 	void ofApp:keyPressed(int key){
 		if(key == 'x'){
 			img.grabScreen(0, 0 , ofGetWidth(), ofGetHeight());
-			img.saveImage("screenshot.png");
+			img.save("screenshot.png");
 		}
 	}
 


### PR DESCRIPTION
In 9.3, it appears that ofImage.saveImage() has been replaced with ofImage.save().