### PR TITLE
changing tutorial links

### DIFF
--- a/documentation/gl/ofGLProgrammableRenderer.markdown
+++ b/documentation/gl/ofGLProgrammableRenderer.markdown
@@ -17,7 +17,7 @@ _extends: ofBaseGLRenderer_
 
 ##Description
 
-The OpenGL programable renderer is a renderer for OF that is built specifically to support both newer versions of OpenGL (3+) as well as supporting GLES, which is what you'll be using if you're running OF on an ARM Linux (i.e. Raspberry Pi), Android, or iOS device. There are a few key differences between OpenGL 3 and OpenGL 2 that are largely hidden from you by OF. You can still use the same methods for drawing, making meshes, uploading textures, and other drawing operations on the programmable renderer as you could on the direct pipeline, so you're not missing anything if you stick to the older pipeline. The most significant difference probably comes in writing GLSL shaders, since the syntax changes between the older implementation and the newer. One of the important things that the ofGLProgrammableRenderer adds is default shaders. That's right: every time you run your OF application, shaders are created and uploaded to the GPU without you even knowing it. There's also addition parameters that are automatically passed to the shader program that you can leverage if you're writing your own. Check out [this tutorial](/tutorials/graphics/shaders.html) for more information.
+The OpenGL programable renderer is a renderer for OF that is built specifically to support both newer versions of OpenGL (3+) as well as supporting GLES, which is what you'll be using if you're running OF on an ARM Linux (i.e. Raspberry Pi), Android, or iOS device. There are a few key differences between OpenGL 3 and OpenGL 2 that are largely hidden from you by OF. You can still use the same methods for drawing, making meshes, uploading textures, and other drawing operations on the programmable renderer as you could on the direct pipeline, so you're not missing anything if you stick to the older pipeline. The most significant difference probably comes in writing GLSL shaders, since the syntax changes between the older implementation and the newer. One of the important things that the ofGLProgrammableRenderer adds is default shaders. That's right: every time you run your OF application, shaders are created and uploaded to the GPU without you even knowing it. There's also addition parameters that are automatically passed to the shader program that you can leverage if you're writing your own. Check out [this chapter](http://openframeworks.cc/ofBook/chapters/openGL.html) about OpenGL in the ofBook and [this blog post](http://blog.openframeworks.cc/post/133400454159/openframeworks-090-opengl-45) for more information on using different OpenGL versions.
 
 To initialize the ofGLProgrammableRenderer call ofSetCurrentRenderer() before you call ofSetupOpenGL() in your main.cpp file:
 
@@ -29,7 +29,16 @@ ofSetupOpenGL(1024,768, OF_WINDOW);         // <-------- setup the GL context
 
 After that, things should remain the same for you whether you're using the older ofGLRenderer or the newer ofGLProgrammableRenderer.
 
-
+Alternatively, in openFrameworks 0.9 you can directly set the OpenGL version as follows: 
+~~~~{.cpp}
+// main.cpp (openFrameworks 0.9)
+int main(){
+    ofGLWindowSettings settings;
+    settings.setGLVersion(4,5); /// < select your GL Version here
+    ofCreateWindow(settings); ///< create your window here
+    ofRunApp(new ofApp());
+}
+~~~~
 
 
 


### PR DESCRIPTION
Issue: #521 
Changed tutorial links (did not point to tutorials anymore) to point at the OpenGL chapter of the ofBook. 
Also included a link to the blog post that describes usage of different OpenGL versions. 

Included the sample from the blog post for choosing OpenGL versions in of 0.9