### PR TITLE
add some link to the documentation part

### DIFF
--- a/learning/contributing_to_docs.md
+++ b/learning/contributing_to_docs.md
@@ -9,8 +9,9 @@ If you are not sure, ask in the forum first. If you want to correct the document
 That is great!
 These are some of the things that we could improve:
 
-* Add a Readme file for each example in the `examples` folder, like in this [example](https://github.com/openframeworks/openFrameworks/tree/master/examples/3d/ofNodeExample)
+* Add a Readme file for each example alredy existing in the `examples` folder, like in this [example](https://github.com/openframeworks/openFrameworks/tree/master/examples/3d/ofNodeExample)
 * Fill the modules documentation. All the modules have its documentation, accessible by clicking on "Module Documentation" on the [documentation page](http://openframeworks.cc/documentation). If you feel that something important is missing, or it is not well explained, open a pull request on the [openFrameworks website repository](https://github.com/openframeworks/ofSite).
+* Write a new tutorial, improve an existing example or add a new one. Here there is a list of what is needed(https://github.com/openframeworks/openFrameworks/wiki/Tutorials%2C-Examples-and-Documentation)
 * Fill classes documentation in the `documentation` folder on the [openFrameworks website repository](https://github.com/openframeworks/ofSite/tree/master/documentation) 
-* Fill function documentation in the source code of the openFrameworks repository.
+* Fill function documentation in the source code of the openFrameworks repository, follow the [doxygen styleguide](https://github.com/openframeworks/openFrameworks/wiki/openFrameworks-doxygen-documentation-style-guidelines).
 


### PR DESCRIPTION
I've read in slack that there are some articles about the doc, I've added them to the how to doc part