### PR TITLE
Adding nikola install step / clarified install info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,22 +24,35 @@ The `documentation` folder contains the OF API reference and are also in markdow
 
 ## Setting up the site to build locally
 
-This site is based on [nikola](https://getnikola.com). There's some scripts in the root folder to make it easier to install and use.
+This site is built using [nikola](https://getnikola.com). There's some scripts in the root folder to make it easier to install and use.
 
-- ./install.sh will install nikola and all the needed dependencies. By now is only tested on linux and osx. On osx, before to run this script, you need first to install these packages:
+1. First, if installing on Mac OS-X, make sure the Xcode command lines tools have been installed:
+
+  ```bash
+  xcode-select --install
+  ```
+  and then install the following packages (If you do not have brew installed you can grab it from [brew.sh](http://brew.sh/)):
+
   ```bash
   brew install python3
   sudo easy_install pip
   brew linkapps python3
   ```
-  and add this to your .basrc or .zshrc file
+
+2. From the ofSite source directory, run ./install.sh which installs nikola and all the needed dependencies. (This has only been tested on linux and OS-X). 
+
+3. Finally add the following to your .basrc, .bash_profile or .zshrc file:
   `export XML_CATALOG_FILES="/usr/local/etc/xml/catalog"`
 
-- ./auto_build.sh will run nikola and build the web every time any file is modified. If, on osx, you receive this error: `FileNotFoundError: [Errno 2] No such file or directory: 'asciidoctor'`, you need to install asciidoctor as explained [here](http://asciidoctor.org/docs/install-asciidoctor-macosx/), and then run the script again.
+There are two scripts included in the ofSite root to help work with the docs:
 
-- ./serve.sh will start a local web server that serves the site and opens it in the browser
+**./auto_build.sh** : Runs nikola and builds the site every time any file is modified.
 
-If you plan to do a big modification like contribute a translation the easiest is to leave the 2 last scripts running and just edit the content files and the site will automatically get refreshed.
+If, on osx, you receive this error: `FileNotFoundError: [Errno 2] No such file or directory: 'asciidoctor'`, you need to install asciidoctor as explained [here](http://asciidoctor.org/docs/install-asciidoctor-macosx/), and then run the script again.
+
+**./serve.sh** : Starts a local web server that serves the site and opens it in the browser.
+
+If you plan to do a big modifications like contribute a translation the easiest is to leave the 2 last scripts running and just edit the content files and the site will automatically get refreshed.
 
 ## Documentation-style markdown
 


### PR DESCRIPTION
On OS-X the xcode command line tools are required to install Nikola (at least on 10.11). I added that step to the documents.

I also broke the steps out a bit so they are a bit clear, and presented in the order of execution.