### PR TITLE
typo fix Update ofUtils_functions.markdown

### DIFF
--- a/documentation/utils/ofUtils_functions.markdown
+++ b/documentation/utils/ofUtils_functions.markdown
@@ -2027,8 +2027,8 @@ Example:
 ~~~~{.cpp}
 
 string filename;
-fileName = "screen1.png";
-ofSaveScreen(fileName);
+filename = "screen1.png";
+ofSaveScreen(filename);
 ~~~~
 
 


### PR DESCRIPTION
fixed typos from "fileName" to "filename"