### PR TITLE
The Mode POLYLINES is inaccessible

### DIFF
--- a/documentation/graphics/ofPath.markdown
+++ b/documentation/graphics/ofPath.markdown
@@ -51,7 +51,7 @@ for( int i = 0; i < 5; i++) {
 To use ofPolyline instances, simply set the mode to POLYLINES
 
 ~~~~{.cpp}
-path.setMode(POLYLINES);
+path.setMode(ofPath::POLYLINES);
 ~~~~
 
 


### PR DESCRIPTION
POLYLINES must be preceded by the ofPath namespace