### PR TITLE
getResampledByCount does indeed add points if necessary

### DIFF
--- a/documentation/graphics/ofPolyline.markdown
+++ b/documentation/graphics/ofPolyline.markdown
@@ -1889,7 +1889,7 @@ _inlined_description: _
 Resamples the line based on the count passed in. The lower the
 count passed in, the more points will be eliminated.
 
-This doesn't add new points to the line.
+New points are added if necessary to match count.
 
 
 
@@ -1897,7 +1897,7 @@ This doesn't add new points to the line.
 
 _description: _
 
-This resamples the line based on the spacing passed in. The lower the count passed in, the more points will be eliminated. This doesn't add new points to the line though.
+This resamples the line based on the spacing passed in. The lower the count passed in, the more points will be eliminated. New points are added if necessary to match count.
 
 
 


### PR DESCRIPTION
I tried calling getResampledByCount(30) on a polyline with 18 points, and the resulting line has 30 points, which seems to contradict what the documentation says.