### PR TITLE
setPixelFormat description added

### DIFF
--- a/documentation/video/ofVideoPlayer.markdown
+++ b/documentation/video/ofVideoPlayer.markdown
@@ -1786,7 +1786,7 @@ _inlined_description: _
 
 
 _description: _
-Choose from OF_PIXELS_RGB or OF_PIXELS_RGBA
+OSX: Choose from OF_PIXELS_RGB or OF_PIXELS_RGBA
 
 
 

--- a/documentation/video/ofVideoPlayer.markdown
+++ b/documentation/video/ofVideoPlayer.markdown
@@ -1786,7 +1786,7 @@ _inlined_description: _
 
 
 _description: _
-
+Choose from OF_PIXELS_RGB or OF_PIXELS_RGBA
 
 
 


### PR DESCRIPTION
Description on setPixelFormat, it was unclear which ofPixelFormats were supported. In ofAVFoundationPlayer I found only these two ofPixelFormats are supported.
