### PR TITLE
Update slack links to heroku app to get around invitation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -187,7 +187,7 @@ EXTERNAL_LINKS = {
         ("https://forum.openframeworks.cc", "forum"),
 	("https://github.com/openframeworks", "github"),
         ("http://ofxaddons.com", "addons"),
-	("http://openframeworks.slack.com", "slack"),
+	("http://ofslack.herokuapp.com/", "slack"),
         ("http://blog.openframeworks.cc/", "blog"),
     ),
 

--- a/content/community.md
+++ b/content/community.md
@@ -55,7 +55,7 @@
 <p>Connect with other developers and contributors.</p>
 <ul>
     <li><a href="https://github.com/openframeworks">Github</a></li>
-	<li><a href="https://openframeworks.slack.com">Slack</a></li>
+	<li><a href="http://ofslack.herokuapp.com">Slack</a></li>
     <li><a href="http://dev.openframeworks.cc/listinfo.cgi/of-dev-openframeworks.cc">Developer Mailing List</a> <span style="font-size:75%">(Low Volume)</span></li>
 	<li><a href="http://webchat.freenode.net/?channels=openframeworks">IRC</a> <span style="font-size:75%">(Low Volume)</span></li>
 </ul>


### PR DESCRIPTION
The links for the OF slack pointed to the official URL, openframeworks.slack.com, which requires an invitation to join. I changed the links to the heroku app which allows anyone to invite themselves.