### PR TITLE
Add note about different Python versions when installing Emscripten

### DIFF
--- a/content/setup/emscripten.md
+++ b/content/setup/emscripten.md
@@ -25,7 +25,10 @@ If you are on Mac or Linux, search for the `Portable Emscripten SDK for Linux an
 # Make the "latest" SDK "active"
 ./emsdk activate latest
 ```
-the installation will take a while. When it is finished, type `source ./emsdk_env.sh` to set the system path to the active version of Emscripten. You can copy the output of this command and add it to your `.profile` file, in order to save this variables also for the next sessions.
+
+_Note: Because the current `emsdk` script uses Python2, you may get errors if the default `python` command on your machine is aliased to Python3. In this case, try explicitly running the above commands with Python2. For example: `python2 ./emsdk update`._
+
+The installation will take a while. When it is finished, type `source ./emsdk_env.sh` to set the system path to the active version of Emscripten. You can copy the output of this command and add it to your `.profile` file, in order to save this variables also for the next sessions.
 
 Compile an openFrameworks project using emscripten
 --------------------------------------


### PR DESCRIPTION
While following along with the Emscripten setup guide, I ran into an issue where I needed to manually run `./emsdk` with Python2, since the default `python` command on my machine pointed to a version of Python3. 

This had me hung up for a while, and I can envision many folks running in to the same problem -- so I added a brief note about it.