### PR TITLE
Update example code to remove deprecated function call

### DIFF
--- a/documentation/utils/ofThread.markdown
+++ b/documentation/utils/ofThread.markdown
@@ -127,7 +127,7 @@ then in the .cpp file:
 void ofApp::setup() {
 
 	// start the thread
-	thread.startThread(true, false);	// blocking, non verbose
+	thread.startThread(true);	// blocking
 }
 
 void ofApp::update() {


### PR DESCRIPTION
ofThread::startThread(bool mutexBlocks, bool verbose) is deprecated