### PR TITLE
Small fix in Linux install instruction + minor CSS change

### DIFF
--- a/files/setup/linux-install/index.html.mako
+++ b/files/setup/linux-install/index.html.mako
@@ -24,14 +24,14 @@ cd OF/scripts/linux
 ./compileOF.sh -j3
 ```
 
-`-j3` tells the script to use 3 CPUs to compile. You can specify as many as you want but it's recommended to use the number of cores in your computer or less.
+`-j3` tells the script to use 3 CPUs to compile. You can specify as many as you want but it's recommended to use the number of cores in your computer or less. On many systems the command `nproc --all` should return the amount of cores available.
 
 With this you can already go into any of the examples folders and compile the examples using make:
 
 ```
 cd OF/examples/graphics/polygonExample
 make
-make Run
+make RunRelease
 ```
 
 Or use any of the officially supported IDEs: [qtcreator](../qtcreator/) or [eclipse](../eclipse/) both IDEs have plugins that allow to create new projects, import existing ones, add addons to them.
@@ -40,7 +40,7 @@ If you want to install the project generator, a tool that allows to create and u
 
 ```
 cd OF/scripts/linux
-./compilePG.sh
+./compilePG.sh -j3
 ```
 
 This will compile the GUI version of the project generator which will be placed in the root of the OF folder. When it's done compiling it will ask you if you also want to install the optional command line version of the tool which allows you to create projects from anywhere on your system.

--- a/themes/openframeworks/assets/css/style.css
+++ b/themes/openframeworks/assets/css/style.css
@@ -419,6 +419,7 @@ a:active {
 	text-decoration: none;
 }
 a.nohover:hover {
+	color: #EE3987;
 	background: none;
 	border: none;
 }

--- a/themes/openframeworks/templates/documentation_function.mako
+++ b/themes/openframeworks/templates/documentation_function.mako
@@ -2,7 +2,7 @@
 <%page args="function"/>
 <div class="documentation_detail ${function.name}" data-lookup="${function.name}" data-item-type="function">
   	<% params = "()" if function.parameters=="" else "(...)" %> 
-	<h1><a name="show_${function.name}">${function.name}${params}</a></h1>
+	<h1><a name="show_${function.name}" class="nohover">${function.name}${params}</a></h1>
 	<h2>${function.returns} ${function.name}(${function.parameters})</h2>
 	<div class="documentation_detail_description">
         ${function.summary}

--- a/themes/openframeworks/templates/documentation_method.mako
+++ b/themes/openframeworks/templates/documentation_method.mako
@@ -2,7 +2,7 @@
 <%page args="method"/>
 <div class="documentation_detail ${method.name}" data-lookup="${method.name}" data-item-type="method">
   	<% params = "()" if method.parameters=="" else "(...)" %> 
-	<h1><a name="show_${method.name}">${method.name}${params}</a></h1>
+	<h1><a name="show_${method.name}" class="nohover">${method.name}${params}</a></h1>
 	<h2>${method.returns} ${method.clazz}::${method.name}(${method.parameters})</h2>
 	<div class="documentation_detail_description">
 		${method.summary}

--- a/themes/openframeworks/templates/documentation_var.mako
+++ b/themes/openframeworks/templates/documentation_var.mako
@@ -1,7 +1,7 @@
 ## -*- coding: utf-8 -*-
 <%page args="var"/>
 <div class="documentation_detail  ${var.name}" data-lookup="${var.name}" data-item-type="var">
-	<h1>${var.type} <a name="show_${var.name}">${var.name}</a></h1>
+	<h1>${var.type} <a name="show_${var.name}" class="nohover">${var.name}</a></h1>
 	<h2>${var.type} ${var.clazz}::${var.name}</h2>
 	<div class="documentation_detail_description">
     ${var.description}


### PR DESCRIPTION
* Fixes a typo in the Linux instructions (`make Run` should be `make RunRelease`)
* Adds a small note on finding the amount of cores available for compiling
* Removes the hover effect from the method name headers in the documentation (see commit for more info)