### PR TITLE
Fixing ofEvent declaration to include const modifier

### DIFF
--- a/documentation/events/ofEvent.markdown
+++ b/documentation/events/ofEvent.markdown
@@ -23,7 +23,7 @@ Class for creating custom events. Also used inside oF for its own events (see of
 ie: To create a new event:
 
 ~~~~{.cpp}
-ofEvent<float> onVolumeChange;
+ofEvent<const float> onVolumeChange;
 ~~~~
 
 To notify an event of that type:


### PR DESCRIPTION
Current ofEvent example doesn't compile. When declaring the event type, you must set it as a const reference. See: https://github.com/openframeworks/openFrameworks/issues/1167