### PR TITLE
correct typo in a comment that was backwards

### DIFF
--- a/documentation/utils/ofFile.markdown
+++ b/documentation/utils/ofFile.markdown
@@ -488,7 +488,7 @@ _description: _
 If the ofFile contains a file path that doesn't exist yet, calling create() generates the file.
 
 ~~~~{.cpp}
-ofFile newFile(ofToDataPath("temp.txt"), ofFile::Write); //file doesn't exist yet
+ofFile newFile(ofToDataPath("temp.txt"), ofFile::Write); // file doesn't exist yet
 newFile.create(); // now file exists
 ~~~~
 
@@ -1319,8 +1319,8 @@ ofFile fileToRead(ofToDataPath("dictionary.txt")); // a file that exists
 ~~~~
 
 ~~~~{.cpp}
-ofFile newFile(ofToDataPath("temp.txt"), ofFile::Write); //file doesn't exist yet
-newFile.create(); // now file doesn't exist 
+ofFile newFile(ofToDataPath("temp.txt"), ofFile::Write); // file doesn't exist yet
+newFile.create(); // now file exists 
 ~~~~
 
 


### PR DESCRIPTION
The comment after the call to .create() should say now the file exists, not that it doesn't exist. This was backwards in one of the two places it appeared. Fixed. Also standardized the space after // in the previous comment in two places.