### PR TITLE
Fixed backwards comment about defaults.

### DIFF
--- a/documentation/utils/ofFileUtils_functions.markdown
+++ b/documentation/utils/ofFileUtils_functions.markdown
@@ -36,7 +36,7 @@ _inlined_description: _
 
 Read the contents of a file at path into a buffer.
 
-Opens as a text file by default.
+Opens as a binary file by default.
 
 
 **Parameters:**
@@ -81,7 +81,7 @@ _inlined_description: _
 
 Write the contents of a buffer to a file at path.
 
-Saves as a text file by default.
+Saves as a binary file by default.
 
 
 **Parameters:**


### PR DESCRIPTION
Both ofBufferToFile and ofBufferFromFile had descriptions saying they were text by default, but as the default parameter shows and the later comments show, the default is binary. Fixed.