### PR TITLE
Fixes layout problem with 'close' methods

### DIFF
--- a/themes/openframeworks/assets/css/style.css
+++ b/themes/openframeworks/assets/css/style.css
@@ -1602,15 +1602,15 @@ table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inh
 }
 
 /* The Close Button */
-.close {
+.close-btn {
     color: white;
     float: right;
     font-size: 28px;
     font-weight: bold;
 }
 
-.close:hover,
-.close:focus {
+.close-btn:hover,
+.close-btn:focus {
     color: #A617CE;
     text-decoration: none;
     cursor: pointer;

--- a/themes/openframeworks/assets/js/donations_popup.js
+++ b/themes/openframeworks/assets/js/donations_popup.js
@@ -4,7 +4,7 @@ function setupDonationsPopup() {
     var modal = document.getElementById('donations_popup');
 
     // Get the <span> element that closes the modal
-    var span = document.getElementsByClassName("close")[0];
+    var span = document.getElementsByClassName("close-btn")[0];
 
     // When the user clicks on <span> (x), close the modal
     span.onclick = function() {

--- a/themes/openframeworks/templates/base.tmpl
+++ b/themes/openframeworks/templates/base.tmpl
@@ -179,7 +179,7 @@ ${set_locale(lang)}
     <div id="donations_popup" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <span class="close">&times;</span>
+                <span class="close-btn">&times;</span>
                 <h2>donate</h2>
             </div>
             <!-- Modal content -->


### PR DESCRIPTION
Some css for the new donation popup (the ```close``` class) was messing with html elements in the documentation (specifically, element relating to ```close``` methods, see https://openframeworks.cc///documentation/utils/ofFile/). 
Fixed by renaming the class for the donation popup from ```close``` to  ```close-btn```

Closes #657