### PR TITLE
Update to current Android Studio setup steps

### DIFF
--- a/content/setup/android-studio.md
+++ b/content/setup/android-studio.md
@@ -12,8 +12,12 @@ Setting up openFrameworks with Android Studio is fairly straightforward. The bas
 - Install Android Studio and the Android SDK
 - Install the Android NDK (actually tested version is r15c)
 - Download openFrameworks from the download page or from git
-- Set the path to the NDK in local.properties (`ndk.dir`)
-- In Android Studio, use **File ➞ Open Project** and select an openFrameworks example from the examples/android folder
+- If you got openFrameworks from git: 
+	- Run `scripts/android/download_libs.sh` to download libraries.
+	- Use the Project Generator to generate Android Studio project files for android examples.
+- In Android Studio, use **Open an existing Android Studio project** and select an openFrameworks example from the `examples/android` folder.
+- It will ask you for NDK location, either put the path in `local.properties` or click *Project Structure* and select the NDK location.
+- Let Android Studio download all other dependencies missing automatically.
 - Build and run
 
 Installation
@@ -40,12 +44,6 @@ This is the C/C++ compiler, headers and libraries for Android. OF 0.10.0 has bee
 
 [Download](/download) it from the downloads page:
 
-
-<h3>Configure the NDK</h3>
-
-With a text editor, edit the file `libs/openFrameworksCompiled/project/android/paths.make` and set the NDK path to the correct folder:
-
-    NDK_ROOT=/path/to/the/ndk
 
 <h3>Open the project</h3>
 


### PR DESCRIPTION
The steps shown on this page have fallen behind what is needed currently. The instructions to "edit the file libs/openFrameworksCompiled/project/android/paths.make" are no longer applicable as paths.make doesn't even exist and that's not the current way to tell Android Studio where the NDK is. So I took the relevant updated lines from the INSTALL_ANDROID_STUDIO.md file in OpenFrameworks0.10.0 for Android and pasted them here in what seems the appropriate place, and removed the obsolete lines. 

I also think probably there are other obsolete details on this page, which could be copied from that more updated file, but the format was not identical and I didn't want to make a mistake, so I just changed what I was confident about. 

I notice that the seeming links to the NDK versions don't work as links - clicking them takes you back to the help page you are already on, so you have to copy the link text to download them from those. Not sure how/if you'd want that fixed exactly, so I didn't go making them links.