### PR TITLE
Revert "Fixed backwards comment about defaults."

### DIFF
--- a/documentation/utils/ofFileUtils_functions.markdown
+++ b/documentation/utils/ofFileUtils_functions.markdown
@@ -36,7 +36,7 @@ _inlined_description: _
 
 Read the contents of a file at path into a buffer.
 
-Opens as a binary file by default.
+Opens as a text file by default.
 
 
 **Parameters:**
@@ -81,7 +81,7 @@ _inlined_description: _
 
 Write the contents of a buffer to a file at path.
 
-Saves as a binary file by default.
+Saves as a text file by default.
 
 
 **Parameters:**


### PR DESCRIPTION
Reverts openframeworks/ofSite#658

This was modifiying the inlined description which should be modified in the code comments not the markdown