### PR TITLE
Remove "popup windows" from summary of content.

### DIFF
--- a/documentation/utils/introduction.markdown
+++ b/documentation/utils/introduction.markdown
@@ -1,4 +1,4 @@
-## Filesystem, threading, popup windows and other utilities
+## Filesystem, threading and other utilities
 
 The utils module, has different kinds of utilities the main groups are:
 


### PR DESCRIPTION
The words "popup" and "windows" only appear on the summary line, and there seems to currently be no mention of either in the content.