### PR TITLE
Fix a file path. / ファイルパスの記載を修正

### DIFF
--- a/learning/05_3d/3d_example_how_to.ja.markdown
+++ b/learning/05_3d/3d_example_how_to.ja.markdown
@@ -24,5 +24,5 @@ void ofApp::draw(){
 }
 ```
 
-openFramworksの`addons/3DModelLoaderExample/`フォルダの中に、完成された作動するサンプルが入っています。
+openFramworksの`examples/3d/3DModelLoaderExample/`フォルダの中に、完成された作動するサンプルが入っています。
 


### PR DESCRIPTION
This sentence is incorrect on line 27.
Finished working sample exists in 'examples/3d/3DModelLoaderExample/'.