### PR TITLE
Fix typo in ofRectangle.markdown

### DIFF
--- a/documentation/types/ofRectangle.markdown
+++ b/documentation/types/ofRectangle.markdown
@@ -2138,7 +2138,7 @@ _description: _
 
 Coordinates (x, y) are considered inside the rectangle if:
 
-`x > rectMinX && x < rectMinX && y > rectMinY && y < rectMaxY`
+`x > rectMinX && x < rectMaxX && y > rectMinY && y < rectMaxY`
 
 
 


### PR DESCRIPTION
x can never be larger AND smaller than `rectMinX`, so I guess it was `rectMaxX` that was meant here.

By the way, should the comparisons be `<=` and `>=` instead?