### PR TITLE
Explain qtcreator qbs dependency

### DIFF
--- a/content/setup/qtcreator.md
+++ b/content/setup/qtcreator.md
@@ -15,9 +15,11 @@ Linux
 
 Before using OF in linux you need to run some install scripts, follow the instructions [here](../linux-install/) if you haven't done so yet.
 
-In linux even if Qt Creator is available in the official repositories for your distributions, it's recommended to install qtcreator from their webpage instead. The one that comes with the distribution (at least in ubuntu) might be outdated and installing the one from the webpage you'll get support for the clang plugin which analizes the code while you type marking any errors more accurately than the default qtcreator static analizer.
+In linux even if Qt Creator is available in the official repositories for your distributions, it's recommended to install qtcreator from their webpage instead. The one that comes with the distribution (at least in ubuntu) might be outdated or have missing core dependenices, and installing the one from the webpage you'll get support for the clang plugin which analizes the code while you type marking any errors more accurately than the default qtcreator static analizer.
 
-Once installed you can install the Qt Creator plugin for openFrameworks that comes with the OF download, you can run the `install_template.sh` script in `scripts/qtcreator` and it'll install everything for you.
+If you decide to install Qt Creator using your distribution package manager, make sure to check the package `qbs` was also included as it is sometimes not installed by default (e.g. Archlinux). Qt Creator will throw critical errors without it.
+
+Once Qt Creator is properly installed add the Qt Creator plugin for openFrameworks that comes with the OF download, you can run the `install_template.sh` script in `scripts/qtcreator` and it'll install everything for you.
 
 Windows
 ----

--- a/content/setup/qtcreator.md
+++ b/content/setup/qtcreator.md
@@ -15,7 +15,7 @@ Linux
 
 Before using OF in linux you need to run some install scripts, follow the instructions [here](../linux-install/) if you haven't done so yet.
 
-In linux even if Qt Creator is available in the official repositories for your distributions, it's recommended to install qtcreator from their webpage instead. The one that comes with the distribution (at least in ubuntu) might be outdated or have missing core dependenices, and installing the one from the webpage you'll get support for the clang plugin which analizes the code while you type marking any errors more accurately than the default qtcreator static analizer.
+In linux even if Qt Creator is available in the official repositories for your distributions, it's recommended to install qtcreator from their webpage instead. The one that comes with the distribution (at least in ubuntu) might be outdated or have missing core dependencies, and installing the one from the webpage you'll get support for the clang plugin which analizes the code while you type marking any errors more accurately than the default qtcreator static analizer.
 
 If you decide to install Qt Creator using your distribution package manager, make sure to check the package `qbs` was also included as it is sometimes not installed by default (e.g. Archlinux). Qt Creator will throw critical errors without it.
 


### PR DESCRIPTION
1) Added a sentence explaining that qbs might be needed to install separately if using usual package manager method.
2) Minor editing for clarity.     