### PR TITLE
Fix typo in ofFbo.markdown

### DIFF
--- a/documentation/gl/ofFbo.markdown
+++ b/documentation/gl/ofFbo.markdown
@@ -1946,7 +1946,7 @@ _inlined_description: _
 
 _description: _
 
-This allows you to get the pixels from an ofFbo and store it in an ofFloatPixels instance. The attachmentPoint parameter allows you indicate which of the textures attached to the fbo you want to grab. The ofShortPixels instance is useful when you want your image as floating point values.
+This allows you to get the pixels from an ofFbo and store it in an ofFloatPixels instance. The attachmentPoint parameter allows you indicate which of the textures attached to the fbo you want to grab. The ofFloatPixels instance is useful when you want your image as floating point values.
 
 
 


### PR DESCRIPTION
Typo/copy-paste error in documentation: the function taking an ofFloatPixels reference referenced ofShortPixels instead in the description.